### PR TITLE
Make the hardware report validate the processed data

### DIFF
--- a/report/summarize_json.ipynb
+++ b/report/summarize_json.ipynb
@@ -478,7 +478,59 @@
     "        new_key = keys_translation[k[0]] + unicode(k[1])\n",
     "        aggregated_percentages[new_key] = v / denom\n",
     "\n",
-    "    return aggregated_percentages"
+    "    return aggregated_percentages\n",
+    "\n",
+    "def validate_finalized_data(data):\n",
+    "    \"\"\" Validate the aggregated and finalized data.\n",
+    "    \n",
+    "    This checks that the aggregated hardware data object contains all the expectd keys\n",
+    "    and that they sum up roughly 1.0.\n",
+    "    \n",
+    "    When a problem is found a message is printed to make debugging easier.\n",
+    "    \n",
+    "    Args:\n",
+    "        data: Data in aggregated form.\n",
+    "    \n",
+    "    Returns:\n",
+    "        True if the data validates correctly, false otherwise.\n",
+    "    \"\"\"\n",
+    "    keys_accumulator = {\n",
+    "        'browserArch': 0.0,\n",
+    "        'cpuCores': 0.0,\n",
+    "        'cpuCoresSpeed': 0.0,\n",
+    "        'cpuVendor': 0.0,\n",
+    "        'cpuSpeed': 0.0,\n",
+    "        'gpuVendor': 0.0,\n",
+    "        'gpuModel': 0.0,\n",
+    "        'resolution': 0.0,\n",
+    "        'ram': 0.0,\n",
+    "        'osName': 0.0,\n",
+    "        'osArch': 0.0,\n",
+    "        'hasFlash': 0.0\n",
+    "    }\n",
+    "    \n",
+    "    # We expect to have at least a key in |data| whose name begins with one\n",
+    "    # of the keys in |keys_accumulator|. Iterate through the keys in |data|\n",
+    "    # and accumulate their values in the accumulator.\n",
+    "    for key, value in data.iteritems():\n",
+    "        if key in [\"inactive\", \"broken\", \"date\"]:\n",
+    "            continue\n",
+    "        \n",
+    "        # Get the name of the property to look it up in the accumulator.\n",
+    "        property_name = key.split('_')[0]\n",
+    "        if property_name not in keys_accumulator:\n",
+    "            print(\"Cannot find {} in |keys_accumulator|\".format(property_name))\n",
+    "            return False\n",
+    "        \n",
+    "        keys_accumulator[property_name] += value\n",
+    "\n",
+    "    # Make sure all the properties add up to 1.0 (or close enough).\n",
+    "    for key, value in keys_accumulator.iteritems():\n",
+    "        if abs(1.0 - value) > 0.05:\n",
+    "            print(\"{} values do not add up to 1.0. Their sum is {}.\".format(key, value))\n",
+    "            return False\n",
+    "\n",
+    "    return True"
    ]
   },
   {
@@ -613,6 +665,7 @@
     "        \n",
     "    # The number of all the fetched records (including inactive and broken).\n",
     "    records_count = frame.count()\n",
+    "    print \"Total record count: {}\".format(records_count)\n",
     "\n",
     "    # Split the submission period in chunks, so we don't run out of resources while aggregating if\n",
     "    # we want to backfill.\n",
@@ -632,6 +685,14 @@
     "        discarded = data.filter(lambda r: r in [REASON_BROKEN_DATA, REASON_INACTIVE]).countByValue()\n",
     "        broken_count = discarded[REASON_BROKEN_DATA]\n",
     "        inactive_count = discarded[REASON_INACTIVE]\n",
+    "        broken_ratio = broken_count / float(records_count)\n",
+    "        inactive_ratio = inactive_count / float(records_count)\n",
+    "        print \"Broken pings ratio: {}\\nInactive clients ratio: {}\".format(broken_ratio, inactive_ratio)\n",
+    "        \n",
+    "        # If we're not seeing sane values for the broken or inactive ratios,\n",
+    "        # bail out early on. There's no point in aggregating.\n",
+    "        if broken_ratio >= 0.9 or inactive_ratio >= 0.9:\n",
+    "            raise Exception(\"Unexpected ratio of broken pings or inactive clients.\")\n",
     "        \n",
     "        # Process the data, transforming it in the form we desire.\n",
     "        processed_data = filtered_data.map(prepare_data)\n",
@@ -651,14 +712,15 @@
     "        collapsed_aggregates = collapse_buckets(aggregated_pings, threshold_to_collapse)\n",
     "        \n",
     "        print \"Post-processing raw values...\"\n",
-    "        broken_ratio = broken_count / float(records_count)\n",
-    "        inactive_ratio = inactive_count / float(records_count)\n",
     "        \n",
     "        processed_aggregates = finalize_data(collapsed_aggregates,\n",
     "                                             valid_records_count,\n",
     "                                             broken_ratio,\n",
     "                                             inactive_ratio,\n",
     "                                             chunk_start)\n",
+    "        \n",
+    "        if not validate_finalized_data(processed_aggregates):\n",
+    "            raise Exception(\"The aggregates failed to validate.\")\n",
     "        \n",
     "        print \"Serializing results locally...\"\n",
     "        # This either appends to an existing file, or creates a new one.\n",
@@ -672,7 +734,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Execute the Job"
+    "### Generate the hardware report"
    ]
   },
   {
@@ -686,13 +748,69 @@
     "start_date = None # Only use this when backfilling, e.g. dt.date(2016,2,1)\n",
     "end_date = None # Only use this when backfilling, e.g. dt.date(2016,3,26)\n",
     "\n",
+    "# Generate the report for the desired period.\n",
+    "generate_report(start_date, end_date)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stitch the files together"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
     "# Fetch the previous data from S3 and save it locally.\n",
     "fetch_previous_state(\"hwsurvey-weekly.json\", \"hwsurvey-weekly-prev.json\")\n",
-    "# Generate the report for the desired period.\n",
-    "generate_report(start_date, end_date)\n",
     "# Concat the json files into the output.\n",
     "print \"Joining JSON files...\"\n",
-    "!jq -s \"[.[]|.[]]\" *.json > \"hwsurvey-weekly.json\"\n",
+    "!jq -s \"[.[]|.[]]\" *.json > \"hwsurvey-weekly.json\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validate and upload the produced output\n",
+    "Attempt to read the file we're going to upload to S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "with open(\"hwsurvey-weekly.json\", \"rt\") as report_json:\n",
+    "    # If we attempt to load invalid JSON from the assembled file,\n",
+    "    # the next function throws.\n",
+    "    json.load(report_json)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We didn't fail so far, so upload our data to S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "# Store the new state to S3. Since S3 doesn't support symlinks, make two copy\n",
     "# of the file: one will always contain the latest data, the other for archiving.\n",
     "archived_file_copy = \"hwsurvey-weekly-\" + datetime.date.today().strftime(\"%Y%d%m\") + \".json\"\n",
@@ -949,6 +1067,78 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Define test coverage for the aggregated data validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def test_validate_finalized_data():\n",
+    "    MISSING_KEYS = {\n",
+    "        'browserArch_x86': 1.0,\n",
+    "        'cpuCores_2': 1.0\n",
+    "    }\n",
+    "\n",
+    "    assert validate_finalized_data(MISSING_KEYS) == False,\\\n",
+    "           \"The validator must fail when expected keys are missing\"\n",
+    "        \n",
+    "    KEYS_NOT_ADDING_UP = {\n",
+    "        'browserArch_x86': 0.5,\n",
+    "        'browserArch_x64': 0.4,\n",
+    "        'cpuCores_1': 1.0,\n",
+    "        'cpuCoresSpeed_2_2.2': 1.0,\n",
+    "        'cpuVendor_Vendor1': 1.0,\n",
+    "        'cpuSpeed_2.2': 1.0,\n",
+    "        'gpuVendor_Vendor3': 1.0,\n",
+    "        'gpuModel_Model1': 1.0,\n",
+    "        'resolution_800x600': 1.0,\n",
+    "        'ram_2': 1.0,\n",
+    "        'osName_SomeOS': 1.0,\n",
+    "        'osArch_x64': 1.0,\n",
+    "        'hasFlash_True': 1.0\n",
+    "    }\n",
+    "\n",
+    "    assert validate_finalized_data(KEYS_NOT_ADDING_UP) == False,\\\n",
+    "           \"The validator must fail when the reported values don't add up to 1.0\"\n",
+    "    \n",
+    "    WORKING_DATA = {\n",
+    "        'browserArch_x86': 0.7,\n",
+    "        'browserArch_x64': 0.29,\n",
+    "        'cpuCores_1': 0.5,\n",
+    "        'cpuCores_2': 0.5,\n",
+    "        'cpuCoresSpeed_2_2.2': 0.1,\n",
+    "        'cpuCoresSpeed_2_2.4': 0.9,\n",
+    "        'cpuVendor_Vendor1': 0.725,\n",
+    "        'cpuVendor_Vendor2': 0.275,\n",
+    "        'cpuSpeed_2.2': 0.1,\n",
+    "        'cpuSpeed_2.4': 0.9,\n",
+    "        'gpuVendor_Vendor3': 0.9,\n",
+    "        'gpuVendor_Vendor4': 0.1,\n",
+    "        'gpuModel_Model1': 0.00001,\n",
+    "        'gpuModel_Model2': 0.99999,\n",
+    "        'resolution_800x600': 1.0,\n",
+    "        'ram_2': 1.0,\n",
+    "        'osName_SomeOS': 1.0,\n",
+    "        'osArch_x64': 1.0,\n",
+    "        'hasFlash_True': 1.0,\n",
+    "        'broken': 0.1,\n",
+    "        'inactive': 0.1,\n",
+    "        'date': '2017-03-26'\n",
+    "    }\n",
+    "\n",
+    "    assert validate_finalized_data(WORKING_DATA),\\\n",
+    "           \"The validator must not fail when the reported data is correct\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Run the test suite."
    ]
   },
@@ -1012,6 +1202,9 @@
     "    \n",
     "    # Test |finalize_data|.\n",
     "    test_finalize_data()\n",
+    "    \n",
+    "    # Test |validate_finalized_data|\n",
+    "    test_validate_finalized_data()\n",
     "\n",
     "run_tests()"
    ]


### PR DESCRIPTION
This adds some sanity checks to data produced by the
report and makes the ETL job fail hard (raising an
exception) if something looks wrong.