### PR TITLE
Minimize bundle.js payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firefox-hardware-report",
   "scripts": {
-    "postinstall": "webpack",
+    "postinstall": "webpack -p",
     "start": "node server",
     "local": "webpack-dev-server --progress --hot --content-base static --port 3000",
     "posttest": "npm audit || true"


### PR DESCRIPTION
Fixes #101 

Before, bundle.js was about 1.7MB, with this PR it's down to 719KB. 

<img width="636" alt="screen shot 2018-07-28 at 3 04 04 pm" src="https://user-images.githubusercontent.com/236451/43360969-f8a0a1a8-9277-11e8-8cf7-10db24ba4fd8.png">
